### PR TITLE
Add test for 0 and '0' in PeriodicalTrigger and Fix '0' case error

### DIFF
--- a/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/Tests/Trigger/PeriodicalTriggerTest.php
@@ -73,6 +73,8 @@ class PeriodicalTriggerTest extends TestCase
         yield ['3600.5'];
         yield ['-3600'];
         yield [-3600];
+        yield ['0'];
+        yield [0];
     }
 
     /**

--- a/Trigger/PeriodicalTrigger.php
+++ b/Trigger/PeriodicalTrigger.php
@@ -30,19 +30,12 @@ class PeriodicalTrigger implements StatefulTriggerInterface
         $this->from = \is_string($from) ? new \DateTimeImmutable($from) : $from;
         $this->until = \is_string($until) ? new \DateTimeImmutable($until) : $until;
 
-        if (\is_int($interval) || \is_float($interval)) {
+        if (\is_int($interval) || \is_float($interval) || \is_string($interval) && ctype_digit($interval)) {
             if (0 >= $interval) {
                 throw new InvalidArgumentException('The "$interval" argument must be greater than zero.');
             }
 
             $this->intervalInSeconds = $interval;
-            $this->description = sprintf('every %d seconds', $this->intervalInSeconds);
-
-            return;
-        }
-
-        if (\is_string($interval) && ctype_digit($interval)) {
-            $this->intervalInSeconds = (int) $interval;
             $this->description = sprintf('every %d seconds', $this->intervalInSeconds);
 
             return;


### PR DESCRIPTION
While taking a peek at the code I found the possibility for this case slipping by the error checking.
To prevent code duplication I took the liberty to also merge the two checks since they are so similar. 

I also wasn't sure to which branche to make the pull request.

Please let me know if there is any feedback on my pull request or if there are any questions.
